### PR TITLE
Allow generateBundleResourceHash to be disabled for release

### DIFF
--- a/android/codepush.gradle
+++ b/android/codepush.gradle
@@ -59,9 +59,11 @@ gradle.projectsEvaluated {
                     type: Exec) {
                 commandLine (*nodeExecutableAndArgs, "${nodeModulesPath}/react-native-code-push/scripts/generateBundledResourcesHash.js", resourcesDir, jsBundleFile, jsBundleDir)
 
-                enabled config."bundleIn${targetName}" ||
-                config."bundleIn${variant.buildType.name.capitalize()}" ?:
-                targetName.toLowerCase().contains("release")
+                enabled config."bundleIn${targetName}" != null
+                  ? config."bundleIn${targetName}"
+                  : config."bundleIn${variant.buildType.name.capitalize()}" != null
+                    ? config."bundleIn${variant.buildType.name.capitalize()}"
+                    : targetName.toLowerCase().contains("release")
             }   
         } else {
             def jsBundleDirConfigName = "jsBundleDir${targetName}"


### PR DESCRIPTION
The logic that was copied from react-native was buggy. The fix to
react-native is here:

https://github.com/facebook/react-native/pull/18892

Basically just apply the same fix, otherwise setting "bundleInRelease"
in a react-native project would fail in the generateBundleResourceHash
step.